### PR TITLE
Use real logger interface for service name

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,20 +103,20 @@ Throwing an exception from the `handleToken()` method will result in all other h
 
 ## Logging
 
-By default, OAuth errors will be logged to PHP’s error log. You can set up your own logging by overriding the `Bigfork\SilverStripeOAuth\Client\Logger` Injector service definition. For example, to log errors to an `oauth.log` file:
+By default, OAuth errors will be logged to PHP’s error log. You can set up your own logging by overriding the `Psr\Log\LoggerInterface.oauth:` Injector service definition. For example, to log errors to an `oauth.log` file:
 
 ```yml
 ---
 After: silverstripe-oauth-logging
 ---
 SilverStripe\Core\Injector\Injector:
-  Bigfork\SilverStripeOAuth\Client\Logger:
+  Psr\Log\LoggerInterface.oauth:
     calls: null # Reset - without this, the below "calls" would be merged in instead of replacing the original
 ---
 After: silverstripe-oauth-logging
 ---
 SilverStripe\Core\Injector\Injector:
-  Bigfork\SilverStripeOAuth\Client\Logger:
+  Psr\Log\LoggerInterface.oauth:
     calls:
       pushDisplayErrorHandler: [ pushHandler, [ '%$OAuthLogFileHandler' ] ]
   OAuthLogFileHandler:

--- a/_config/logging.yml
+++ b/_config/logging.yml
@@ -2,10 +2,12 @@
 Name: silverstripe-oauth-logging
 ---
 SilverStripe\Core\Injector\Injector:
-  Bigfork\SilverStripeOAuth\Client\Logger:
+  Psr\Log\LoggerInterface.oauth:
     type: singleton
     class: Monolog\Logger
     constructor:
       - "oauth-error-log"
     calls:
       pushDisplayErrorHandler: [ pushHandler, [ '%$Monolog\Handler\ErrorLogHandler' ] ]
+  # Alias for old service name
+  Bigfork\SilverStripeOAuth\Client\Logger: '%$Psr\Log\LoggerInterface.oauth'

--- a/src/Factory/ProviderFactory.php
+++ b/src/Factory/ProviderFactory.php
@@ -2,8 +2,8 @@
 
 namespace Bigfork\SilverStripeOAuth\Client\Factory;
 
-use Bigfork\SilverStripeOAuth\Client\Authenticator\Authenticator;
 use InvalidArgumentException;
+use League\OAuth2\Client\Provider\AbstractProvider;
 
 class ProviderFactory
 {
@@ -29,7 +29,7 @@ class ProviderFactory
 
     /**
      * @param string $name
-     * @return League\OAuth2\Client\Provider\AbstractProvider
+     * @return AbstractProvider
      */
     public function getProvider($name)
     {


### PR DESCRIPTION
See https://github.com/littlegiant/silverstripe-oauth/commit/ba669b6140fa7dfc31920e458f8ef9a5e64062e4

Although the previous code worked, it triggered an IDE warning which will likely make people confused about how to set their logger, so I've updated it to use a named LoggerInterface service name.

Also, `$provider->getDefaultScopes();` was erroring when calling a protected method so it's been removed. It not must be provided via url.

cc @kinglozzer 