### PR TITLE
Add error handler to handle errors better

### DIFF
--- a/src/Handler/ErrorHandler.php
+++ b/src/Handler/ErrorHandler.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Bigfork\SilverStripeOAuth\Client\Handler;
+
+use League\OAuth2\Client\Provider\AbstractProvider;
+use SilverStripe\Control\HTTPRequest;
+
+interface ErrorHandler
+{
+    /**
+     * @param string $message
+     * @param AbstractProvider $provider
+     * @param HTTPRequest $request
+     * @return void
+     */
+    public function handleError(&$message, AbstractProvider $provider, HTTPRequest $request);
+}


### PR DESCRIPTION
This PR refers to this issue: https://github.com/bigfork/silverstripe-oauth/issues/12
Allow the handleError method in ErrorHandler interface to handle the exceptions
