### PR TITLE
Silverstripe 5 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "league/oauth2-client": "^2",
-        "silverstripe/framework": "^4"
+        "silverstripe/framework": "^4 | ^5"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7"


### PR DESCRIPTION
Checked against an Auth0 installation and it seems to work OK.  The league/oauth-client is still on major ^2 upstream, so the dependency doesn't need to be changed. 