### PR TITLE
Updated AbsoluteLink

### DIFF
--- a/src/Control/Controller.php
+++ b/src/Control/Controller.php
@@ -76,7 +76,7 @@ class Controller extends SilverStripeController
     /**
      * @return string
      */
-    public function AbsoluteLink()
+    public function AbsoluteLink($action = '')
     {
         return static::join_links(Director::absoluteBaseURL(), $this->Link());
     }


### PR DESCRIPTION
I was receiving the following error on silverstripe 5.1, php 8.1:
```
Fatal error: Declaration of Bigfork\SilverStripeOAuth\Client\Control\Controller::AbsoluteLink() must be compatible with SilverStripe\Control\RequestHandler::AbsoluteLink($action = '') in C:\xampp-8.1\htdocs\silverstripe-install\vendor\bigfork\silverstripe-oauth\src\Control\Controller.php on line 79
ERROR [UNKNOWN TYPE, ERRNO 64]: Declaration of Bigfork\SilverStripeOAuth\Client\Control\Controller::AbsoluteLink() must be compatible with SilverStripe\Control\RequestHandler::AbsoluteLink($action = '') IN GET / Line 79 in C:\xampp-8.1\htdocs\silverstripe-install\vendor\bigfork\silverstripe-oauth\src\Control\Controller.php Source ====== 70: $backUrl = Director::absoluteBaseURL(); 71: } 72: 73: return $backUrl; 74: } 75: 76: /** 77: * @return string 78: */ * 79: public function AbsoluteLink() 80: { 81: return static::join_links(Director::absoluteBaseURL(), $this->Link()); 82: } 83: 84: /** 85: * This takes parameters like the provider, scopes and callback url, builds an authentication Trace ===== SilverStripe\Logging\DetailedErrorFormatter->output(64, Declaration of Bigfork\SilverStripeOAuth\Client\Control\Controller::AbsoluteLink() must be compatible with SilverStripe\Control\RequestHandler::AbsoluteLink($action = ''), C:\xampp-8.1\htdocs\silverstripe-install\vendor\bigfork\silverstripe-oauth\src\Control\Controller.php, 79, ) DetailedErrorFormatter.php:55 SilverStripe\Logging\DetailedErrorFormatter->format(Monolog\LogRecord) AbstractProcessingHandler.php:42 Monolog\Handler\AbstractProcessingHandler->handle(Monolog\LogRecord) Logger.php:389 Monolog\Logger->addRecord(Monolog\Level, Fatal Error (E_COMPILE_ERROR): Declaration of Bigfork\SilverStripeOAuth\Client\Control\Controller::AbsoluteLink() must be compatible with SilverStripe\Control\RequestHandler::AbsoluteLink($action = ''), Array) Logger.php:579 Monolog\Logger->log(Monolog\Level, Fatal Error (E_COMPILE_ERROR): Declaration of Bigfork\SilverStripeOAuth\Client\Control\Controller::AbsoluteLink() must be compatible with SilverStripe\Control\RequestHandler::AbsoluteLink($action = ''), Array) ErrorHandler.php:247 Monolog\ErrorHandler->handleFatalError()
```

I just updated the AbsoluteLink function with $action